### PR TITLE
Prova da (issue #21)

### DIFF
--- a/Fad/Chapter3.lean
+++ b/Fad/Chapter3.lean
@@ -32,15 +32,15 @@ def consSL : α  → SymList α → SymList α
 | z, (xs, []) => ([z], xs)
 | z, (xs, ys) => (z :: xs, ys)
 
-example (x : α) (xs : SymList α)
- : (snoc x ∘ fromSL) xs = (fromSL ∘ snocSL x) xs
- := by
- have (as, bs) := xs
- unfold Function.comp snoc
- induction as generalizing bs with
- | nil =>
-   simp [snocSL, fromSL]; sorry
- | cons y ys ih => sorry
+example (x : α) (xs : SymList α) (h : xs.1 ≠ []) :
+  (snoc x ∘ fromSL) xs = (fromSL ∘ snocSL x) xs :=
+by
+  cases xs with
+  | mk as bs =>
+    cases as with
+    | nil => contradiction
+    | cons a as' =>
+      simp [fromSL, snoc, snocSL, List.reverse_cons, List.append_assoc]
 
 
 end SL1


### PR DESCRIPTION
Precisei assumir que xs.1 ≠ [] (ou seja, que a primeira parte da SymList não está vazia), porque, quando o primeiro lado da lista simétrica está vazio, a definição de snocSL faz uma reorganização nos componentes para manter a estrutura válida.

Isso quebra a igualdade com snoc x (fromSL (xs.1, xs.2)), pois os lados da SymList mudam de lugar, e a lista final construída por fromSL não coincide com a lista obtida aplicando snoc diretamente.

Com xs.1 ≠ [], essa troca não acontece, e aí funciona normalmente.