### PR TITLE
Prova da issue #29

### DIFF
--- a/Fad/Chapter7-Ex.lean
+++ b/Fad/Chapter7-Ex.lean
@@ -104,10 +104,12 @@ example (x : Nat) : ∀ xs, xs ≠ [] →
  induction xs with
  | nil => contradiction
  | cons a as ih =>
-   rw [List.map]
-   rw [minimum]
-   sorry
-
+   cases as with
+   | nil => simp [minimum, Chapter6.foldr1]
+   | cons z zs =>
+   apply Eq.trans (congrArg (min_list_list (x :: a)) (ih (by simp)))
+   simp [min_list_list]
+   rfl
 
 /- # Exercicio 7.10  -/
 


### PR DESCRIPTION
Para provar o caso de `xs = a::as` (`xs` não vazio), primeiro começamos com `as` vazio (=> `xs = [a]`), o que é resolvido aplicando as definições de minimum e foldr1 do Capítulo 6. Já para o caso em que `as = z :: zs` (`xs = a :: z :: zs`, é utilizado o `congrArg` para mostrar congruência nos argumentos da ih aplicando `min_list_list (x :: a)`. Em seguida, o `Eq.trans` é usado para substituir o resultado por transitividade. Ou seja, substituímos `minimum (List.map (fun x_1 => x :: x_1) (a :: z :: zs))` no lado esquerdo da meta por `(x :: minimum (z :: zs))`. Em seguida, resta apenas aplicar o `min_list_list` para completar a prova.