### PR TITLE
fix(chapter4): complete flatten proof in Ex 4.7

### DIFF
--- a/Fad/Chapter4-Ex.lean
+++ b/Fad/Chapter4-Ex.lean
@@ -71,18 +71,24 @@ def flatcat : (t : Tree a) → (xs: List a) → List a
 def Tree.flatten₁ (t : Tree a) : List a :=
  flatcat t []
 
+theorem flatten_eq_helper_accum (t : Tree a) (xs: List a) :
+  t.flatten ++ xs = flatcat t xs := by
+  induction t generalizing xs with
+  | null => rfl
+  | node l x r ihl ihr =>
+    rw [flatcat, <- ihr]
+    rw [← ihl (x :: (r.flatten ++ xs))]
+    rw [List.append_cons]
+    rw [← List.append_assoc]
+    rw [Tree.flatten]
 
 example (t: Tree a) :
   t.flatten = t.flatten₁ := by
   induction t with
   | null => exact rfl
   | node l x r ihl ihr =>
-    simp [Tree.flatten₁]
-    simp [Tree.flatten]
-    simp [flatcat]
-    simp [ihl, ihr]
-    simp [Tree.flatten₁]
-    sorry
+    rw [Tree.flatten₁]
+    simp [← flatten_eq_helper_accum]
 
 end BST1
 


### PR DESCRIPTION
Completed the formalization of Exercise 4.7 by proving the equivalence between the naive flatten and the tail-recursive version.

Closes #61 