### PR TITLE
Exercise 3.10 solved

### DIFF
--- a/Fad/Chapter1-Ex.lean
+++ b/Fad/Chapter1-Ex.lean
@@ -323,6 +323,23 @@ theorem replace_foldr_f_eq : replace ∘ List.foldr f 0 = List.foldr f 0 := by
   exact hfus
 
 
+/- # Exercício 1.18 -/
+
+theorem foldl_fusion {a b c : Type}
+  (f : c → a → c) (g : b → a → b) (h : c → b)
+  (h₁ : ∀ (y : c) (x : a), h (f y x) = g (h y) x)
+  : ∀ (y : c) (xs : List a), h (List.foldl f y xs) = List.foldl g (h y) xs := by
+  intro y xs
+  induction xs generalizing y with
+  | nil =>
+    rfl
+  | cons x xs ih =>
+    rewrite [List.foldl]
+    rewrite [ih]
+    rewrite [h₁]
+    rfl
+
+
 /- # Exercicio 1.20 -/
 
 def concat {α : Type} (xss : List (List α)) : List α :=

--- a/Fad/Chapter1-Ex.lean
+++ b/Fad/Chapter1-Ex.lean
@@ -277,6 +277,52 @@ partial def perms₃ {α : Type} [DecidableEq α] : List α → List (List α)
   as.flatMap (λ x => (perms₃ (remove x as)).map (λ ys => x :: ys))
 
 
+/- # Exercício 1.17 -/
+
+theorem foldr_fusion_context_sensitive {a b c : Type}
+ (f : a → c → c) (e : c) (xs : List a)
+ (g : a → b → b) (h : c → b)
+ (h₁ : ∀ (x : a) (ys : List a), h (f x (List.foldr f e ys)) = g x (h (List.foldr f e ys)))
+ : h (List.foldr f e xs) = List.foldr g (h e) xs := by
+ induction xs with
+  | nil => rfl
+  | cons x xs ih =>
+    rewrite [List.foldr]
+    rewrite [h₁ x xs]
+    rewrite [ih]
+    rfl
+
+def replace (x : Int) : Int := if Even x then x else 0
+
+def f (x y : Int) : Int := 2 * x + y
+
+theorem foldr_f_even (xs : List Int) : Even (List.foldr f 0 xs) := by
+  induction xs with
+  | nil =>
+    use 0
+    rfl
+  | cons x xs ih =>
+    simp [f]
+    simp [Int.even_add]
+    exact ih
+
+theorem replace_foldr_f_eq : replace ∘ List.foldr f 0 = List.foldr f 0 := by
+  funext xs
+  have h₁ : ∀ (x : Int) (ys : List Int),
+      replace (f x (List.foldr f 0 ys)) = f x (replace (List.foldr f 0 ys)) := by
+    intro x ys
+    have heven₁ : Even (List.foldr f 0 ys) := foldr_f_even ys
+    have heven₂ : Even (f x (List.foldr f 0 ys)) := by
+      simp [f]
+      simp [Int.even_add]
+      exact heven₁
+    simp [replace]
+    simp [heven₁]
+    simp [heven₂]
+  have hfus := foldr_fusion_context_sensitive f 0 xs f replace h₁
+  exact hfus
+
+
 /- # Exercicio 1.20 -/
 
 def concat {α : Type} (xss : List (List α)) : List α :=

--- a/Fad/Chapter3-Ex.lean
+++ b/Fad/Chapter3-Ex.lean
@@ -213,23 +213,61 @@ termination_by x1 => measure x1
 def toRA {a : Type} : List a → RAList a :=
   List.foldr consRA nilRA
 
+/-- Just trying to prove the example below. I created two ways of proof. The
+first one I used `calc` and `apply?` helped a lot , despite it looks ugly. But
+the second one (comented) I guess is more elegant and convenient, using `show` -/
+theorem fromRA_consT {a : Type} (t : Tree a) (ds : RAList a) :
+    fromRA (consRA.consT t ds) = fromT t ++ fromRA ds := by
+  induction ds generalizing t with
+  | nil => rfl
+  | cons d ds ih =>
+    cases d with
+    | zero => rfl
+    | one t₂ =>
+      calc
+      fromRA (Digit.zero :: consRA.consT (Tree.mk t t₂) ds)
+          = fromRA (consRA.consT (Tree.mk t t₂) ds) := by
+              simp [fromRA, concatMap, concat1]
+              exact Eq.symm ((fun {α} {xs} => List.nil_eq.mpr) rfl)
+      _ = fromT (Tree.mk t t₂) ++ fromRA ds := by
+              exact ih (Tree.mk t t₂)
+      _ = fromT t ++ fromRA (Digit.one t₂ :: ds) := by
+              simp [fromRA, concatMap, concat1, fromT, Tree.mk, List.append_assoc]
+              exact List.toList_toArray
+
 example : ∀ (xs : List a), xs = fromRA (toRA xs) := by
   intro xs
   induction xs with
   | nil => rfl
   | cons x xs ih =>
-    simp [toRA, fromRA, consRA]
-    rw [ih]
-    match toRA xs with
-    | [] => rfl
-    | (Digit.zero :: ds) =>
-      simp [fromRA]
-      rw [concatMap]
-      sorry
-    | (Digit.one t :: ds) =>
-      simp [fromRA]
-      rw [concatMap]
-      sorry
+    simp [toRA]
+    unfold consRA
+    simp [fromRA_consT, fromT]
+    exact List.append_cancel_left (congrArg (HAppend.hAppend xs) ih)
+
+-- theorem fromRA_consT {a : Type} (t : Tree a) (ds : RAList a) :
+--     fromRA (consRA.consT t ds) = fromT t ++ fromRA ds := by
+--   induction ds generalizing t with
+--   | nil => rfl
+--   | cons d ds ih =>
+--     cases d with
+--     | zero => rfl
+--     | one t₂ =>
+--       show fromRA (consRA.consT (Tree.mk t t₂) ds) = fromT t ++ (fromT t₂ ++ fromRA ds)
+--       rw [ih]
+--       show fromT t ++ fromT t₂ ++ fromRA ds = fromT t ++ (fromT t₂ ++ fromRA ds)
+--       rw [List.append_assoc]
+
+-- example : ∀ (xs : List a), xs = fromRA (toRA xs) := by
+--   intro xs
+--   induction xs with
+--   | nil => rfl
+--   | cons x xs ih =>
+--     show x :: xs = fromRA (consRA.consT (Tree.leaf x) (toRA xs))
+--     rw [fromRA_consT]
+--     show x :: xs = x :: fromRA (toRA xs)
+--     rw [← ih]
+
 
 -- 3.11
 


### PR DESCRIPTION
Proving that $`\texttt{xs} = fromRA\; (toRA\; \texttt{xs})`$ using the theorem $`fromRA\_consT`$ that proves that $`fromRA\; (consRA.consT\; \texttt{t}\; \texttt{ds}) = fromT\; \texttt{t} ++ fromRA\; \texttt{ds}`$.